### PR TITLE
fix compilation warnings

### DIFF
--- a/lhsmtool_phobos.c
+++ b/lhsmtool_phobos.c
@@ -297,7 +297,13 @@ static int ct_parseopts(int argc, char * const *argv)
              opt.o_verbose++;
              break;
         case 'x':
-            strncpy(trusted_fuid_xattr, optarg, MAXNAMLEN);
+            rc = snprintf(trusted_fuid_xattr, sizeof(trusted_fuid_xattr),
+                         "%s", optarg);
+            if (rc >= (int)sizeof(trusted_fuid_xattr)) {
+                rc = -EINVAL;
+                pho_error(rc, "trusted_fuid_xattr too long");
+                return rc;
+            }
             break;
         case 0:
              break;

--- a/lhsmtool_phobos.spec.in
+++ b/lhsmtool_phobos.spec.in
@@ -31,7 +31,7 @@ runs Phobos' LRS daemon (version >= 2.2).
 %autosetup
 
 %build
-%meson
+%meson -Dwerror=false
 %meson_build
 
 %install

--- a/tests/hsm_import.c
+++ b/tests/hsm_import.c
@@ -112,8 +112,8 @@ int open_with_extension(const char *base, const char *extension, int flags)
         return -1;
     }
 
-    strncpy(buf, base, base_len);
-    strncpy(buf + base_len, extension, extension_len);
+    memcpy(buf, base, base_len);
+    memcpy(buf + base_len, extension, extension_len);
     buf[base_len + extension_len] = '\0';
 
     fd = open(buf, flags);


### PR DESCRIPTION
phobos commit 87aefbe7801c ("attrs: remove rc of pho_attrs_set") make pho_attr_set (no s...) retun void, update to use the new API.

Since it was decided this cannot fail, we do not really need to bother with backwards compatibility here for older phobos.

Fixes: #3